### PR TITLE
Bugfix: Use saved player name from local storage

### DIFF
--- a/PlanningPoker.Web/ViewModels/GameViewModel.cs
+++ b/PlanningPoker.Web/ViewModels/GameViewModel.cs
@@ -60,15 +60,15 @@ namespace PlanningPoker.Web.ViewModels
             Player player = null;
             if (await this.LocalStorage.ContainKeyAsync(nameof(Player)) == true)
             {
-                var loadedPlayer = await this.LocalStorage.GetItemAsync<Player>(nameof(Player));
+                player = await this.LocalStorage.GetItemAsync<Player>(nameof(Player));
 
-                if (loadedPlayer.Secret != Guid.Empty)
+                if (player.Secret != Guid.Empty)
                 {
-                    this.Player = loadedPlayer;
+                    this.Player = player;
                 }
             }
 
-            if (player is null)
+            if (this.Player is null)
             {
                 player = new Player()
                 {


### PR DESCRIPTION
Currently, a player name is generated every time a player reloads the page.
This bugfix uses re-enabled the automatical usage of previously entered custom player name.